### PR TITLE
Issue 21: Grails apps will not deploy to Glassfish 4+

### DIFF
--- a/grails-async/src/main/groovy/org/grails/async/factory/future/CachedThreadPoolPromiseFactory.groovy
+++ b/grails-async/src/main/groovy/org/grails/async/factory/future/CachedThreadPoolPromiseFactory.groovy
@@ -105,7 +105,7 @@ class CachedThreadPoolPromiseFactory extends AbstractPromiseFactory implements C
 
     @Override
     @PreDestroy
-    void close() throws IOException {
+    void close() {
         if(!executorService.isShutdown()) {
             executorService.shutdown()
         }


### PR DESCRIPTION
Methods annotated with `@PreDestroy` should not throw a checked exception.

This is documented at https://docs.oracle.com/javaee/7/api/javax/annotation/PreDestroy.html