### PR TITLE
Update promises.adoc

### DIFF
--- a/src/main/docs/guide/promises.adoc
+++ b/src/main/docs/guide/promises.adoc
@@ -182,11 +182,11 @@ Working with `PromiseMap` instances is largely similar. Again you can either use
 ----
 import static grails.async.Promises.*
 
-def promiseList = tasks one:{ 2 * 2 }, 
-                        two:{ 4 * 4}, 
-                        three:{ 8 * 8 }
+def promiseMap = tasks one:{ 2 * 2 }, 
+                       two:{ 4 * 4}, 
+                       three:{ 8 * 8 }
 
-assert [one:4,two:16,three:64] == promiseList.get()
+assert [one:4,two:16,three:64] == promiseMap.get()
 ----
 
 Or construct a `PromiseMap` manually:


### PR DESCRIPTION
Change variable name promiseList to promiseMap as promiseList is a little confusing when code creates an instance of grails.async.PromiseMap, not grails.async.PromiseList