### PR TITLE
chore: Fix code comment about reactor events

### DIFF
--- a/grails-plugin-events/src/main/groovy/org/grails/plugins/events/EventBusGrailsPlugin.groovy
+++ b/grails-plugin-events/src/main/groovy/org/grails/plugins/events/EventBusGrailsPlugin.groovy
@@ -49,7 +49,7 @@ class EventBusGrailsPlugin extends Plugin {
             eventBus(EventBus, ref('grailsEventBus'))
 
 
-            // make it possible to disable reactor events
+            // make it possible to enable reactor events
             if(config.getProperty(TRANSLATE_SPRING_EVENTS, Boolean.class, false)) {
                 springEventTranslator(SpringEventTranslator, ref('grailsEventBus'))
             }


### PR DESCRIPTION
This comment was not updated from when the default was to have reactor events enabled. Since https://github.com/grails/grails-async/commit/229a888e03842cd82eba790225500992b28aa940 this changed to default=false.