### PR TITLE
test: Set longer timeout on test

### DIFF
--- a/examples/pubsub-demo/src/integration-test/groovy/pubsub/demo/PubSubSpec.groovy
+++ b/examples/pubsub-demo/src/integration-test/groovy/pubsub/demo/PubSubSpec.groovy
@@ -24,7 +24,7 @@ class PubSubSpec extends Specification {
             sumService.sum(1, 2)
 
         then: 'the subscriber should receive the events'
-            new PollingConditions(timeout: 5).eventually {
+            new PollingConditions(initialDelay: 0.5, delay: 0.5, timeout: 10).eventually {
                 totalService.accumulatedTotal == 6
             }
     }


### PR DESCRIPTION
A test in PubSubSpec occasionally times out in CI.
Adding an initialDelay, longer delay and longer timeout to the PollingConditions to try and clear this problem.