### PR TITLE
test: Fix async test

### DIFF
--- a/examples/pubsub-demo/grails-app/services/pubsub/demo/TotalService.groovy
+++ b/examples/pubsub-demo/grails-app/services/pubsub/demo/TotalService.groovy
@@ -4,15 +4,21 @@ import grails.events.Event
 import grails.events.annotation.Subscriber
 import groovy.transform.CompileStatic
 
+import java.util.concurrent.atomic.AtomicInteger
+
 @CompileStatic
 class TotalService {
 
-    int accumulatedTotal = 0
+    AtomicInteger accumulatedTotalInstance = new AtomicInteger(0)
+
+    int getAccumulatedTotal() {
+        accumulatedTotalInstance.get()
+    }
 
     @Subscriber
     @SuppressWarnings('unused')
     void onSum(int total) {
-        accumulatedTotal += total
+        accumulatedTotalInstance.addAndGet(total)
     }
 
     @Subscriber

--- a/examples/pubsub-demo/src/integration-test/groovy/pubsub/demo/PubSubSpec.groovy
+++ b/examples/pubsub-demo/src/integration-test/groovy/pubsub/demo/PubSubSpec.groovy
@@ -24,7 +24,7 @@ class PubSubSpec extends Specification {
             sumService.sum(1, 2)
 
         then: 'the subscriber should receive the events'
-            new PollingConditions(initialDelay: 0.5, delay: 0.5, timeout: 10).eventually {
+            new PollingConditions().eventually {
                 totalService.accumulatedTotal == 6
             }
     }


### PR DESCRIPTION
The test sometimes failed because two events updated the same value at the same time. Using an AtomicInteger instead of an int should solve the problem.