### PR TITLE
chore(ci): update gradle-build-action

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -118,7 +118,7 @@ jobs:
           echo "${{ steps.ge_conf.outputs.value }}" | sed -i -e "20r /dev/stdin" settings.gradle
 
       - name: Build and install Groovy (no docs)
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         env:
           GRADLE_SCANS_ACCEPT: yes
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build Project
         id: build_grails_project
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         env:
           GROOVY_VERSION: ${{ needs.build_groovy.outputs.groovySnapshotVersion }}
           CI_GROOVY_VERSION: ${{ needs.build_groovy.outputs.groovySnapshotVersion }}


### PR DESCRIPTION
The GitHub action actions/gradle-build-action@v2 is now deprecated and superseded with gradle/actions/setup-gradle@v3.

GitHub also warns about a security issue with the old version.