### PR TITLE
refactor: Decouple grails-gsp component versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 version = projectVersion
-ext.set('grailsVersion', libs.versions.grails.get())
+ext.set('grailsVersion', libs.versions.grails.asProvider().get())
 ext.set('isSnapshot', projectVersion.endsWith('-SNAPSHOT'))
 ext.set('isReleaseVersion', !isSnapshot)
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -57,7 +57,7 @@ tasks.register('generateGuide', PublishGuide) {
             'javaee'   : 'https://docs.oracle.com/javaee/7/api/',
             'javase'   : 'https://docs.oracle.com/en/java/javase/11/docs/api/',
             'groovyapi': "https://docs.groovy-lang.org/${libs.versions.groovy.get()}/html/gapi/",
-            'grailsapi': "https://docs.grails.org/${libs.versions.grails.get()}/api/",
+            'grailsapi': "https://docs.grails.org/${libs.versions.grails.asProvider().get()}/api/",
             'gormapi'  : "https://gorm.grails.org/${libs.versions.gorm.get()}/api/",
             'springapi': "https://docs.spring.io/spring/docs/${libs.versions.spring.get()}/javadoc-api/"
     ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 bytebuddy = '1.14.11'
 gpars = '1.2.1'
 grails = '6.1.2'
+grails-gsp = '6.1.3'
 groovy = '3.0.19'
 gorm = '8.0.3'
 javax-annotation = '1.3.2'
@@ -23,7 +24,7 @@ grails-datastore-gorm = { module = 'org.grails:grails-datastore-gorm', version.r
 grails-datastore-gorm-test = { module = 'org.grails:grails-datastore-gorm-test', version.ref = 'gorm' }
 grails-web-common = { module = 'org.grails:grails-web-common', version.ref = 'grails' }
 grails-web-mvc = { module = 'org.grails:grails-web-mvc', version.ref = 'grails' }
-grails-web-sitemesh = { module = 'org.grails:grails-web-sitemesh', version.ref = 'grails' }
+grails-web-sitemesh = { module = 'org.grails:grails-web-sitemesh', version.ref = 'grails-gsp' }
 gpars = { module = 'org.codehaus.gpars:gpars', version.ref = 'gpars' }
 groovy-core = { module = 'org.codehaus.groovy:groovy', version.ref = 'groovy' }
 javax-annotation-api = { module = 'javax.annotation:javax.annotation-api', version.ref = 'javax-annotation' }


### PR DESCRIPTION
Versions for components from grails-gsp are now decoupled from the grails version.