### PR TITLE
chore(ci): fix problem with reading versions

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Get version of Gradle Enterprise plugin
         id: gradle_enterprise_version
         run: |
-          GE_PLUGIN_VERSION=$(grep -m 1 'id\s*\(\"com.gradle.enterprise\"\|'"'com.gradle.enterprise'"'\)\s*version' settings.gradle | sed -E "s/.*version[[:space:]]*['\"]?([0-9]+\.[0-9]+\.[0-9]+)['\"]?.*/\1/" | tr -d [:space:])
-          GE_USER_DATA_PLUGIN_VERSION=$(grep -m 1 'id\s*\(\"com.gradle.common-custom-user-data-gradle-plugin\"\|'"'com.gradle.common-custom-user-data-gradle-plugin'"'\)\s*version' settings.gradle | sed -E "s/.*version[[:space:]]*['\"]?([0-9]+\.[0-9]+\.[0-9]+)['\"]?.*/\1/" | tr -d [:space:])
+          GE_PLUGIN_VERSION=$(grep -m 1 'id\s*\(\"com.gradle.enterprise\"\|'"'com.gradle.enterprise'"'\)\s*version' settings.gradle | sed -E "s/.*version[[:space:]]*['\"]?([0-9]+\.[0-9]+(\.[0-9]+)?)['\"]?.*/\1/" | tr -d [:space:])
+          GE_USER_DATA_PLUGIN_VERSION=$(grep -m 1 'id\s*\(\"com.gradle.common-custom-user-data-gradle-plugin\"\|'"'com.gradle.common-custom-user-data-gradle-plugin'"'\)\s*version' settings.gradle | sed -E "s/.*version[[:space:]]*['\"]?([0-9]+\.[0-9]+(\.[0-9]+)?)['\"]?.*/\1/" | tr -d [:space:])
           echo "Project uses Gradle Enterprise Plugin version: $GE_PLUGIN_VERSION"
           echo "Project uses Gradle Common Custom User Data Plugin version: $GE_USER_DATA_PLUGIN_VERSION"
           echo "ge_plugin_version=$GE_PLUGIN_VERSION" >> $GITHUB_OUTPUT

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ if(isReleaseVersion) {
 subprojects {
     version = rootProject.version
     repositories {
+        mavenLocal() // Used by Groovy Joint Workflow
         mavenCentral()
         maven { url = 'https://repo.grails.org/grails/core' }
         if (libs.versions.groovy.get().endsWith('-SNAPSHOT')) {


### PR DESCRIPTION
Gradle Enterprise Plugins can publish versions without the patch version. This commit takes that into account.