### PR TITLE
fix(deps): Remove unused `grails-plugin-events` dependency

### DIFF
--- a/grails-plugin-async/build.gradle
+++ b/grails-plugin-async/build.gradle
@@ -10,18 +10,6 @@ plugins  {
 dependencies {
 
     api project(':grails-async-core')
-
-    // This project does not really depend on the events plugin
-    // but rather on the events-core and events-compat modules.
-    // This is a workaround because without this, many plugins
-    // will not get the events plugin automatically on the classpath
-    // and will get an error.
-    // The async plugin is automatically added to the classpath by
-    // grails-core/grails-dependencies and now also the events plugin
-    // should be pulled in. This will be removed in Grails 7.
-    // https://github.com/grails/grails-core/issues/13324
-    api project(':grails-plugin-events')
-
     api project(':grails-events-compat')
     api project(':grails-events-core')
     api libs.grails.core


### PR DESCRIPTION
`grails-plugin-events` is not a dependency of `grails-plugin-async`.

Related:
https://github.com/grails/grails-core/pull/13723 (should be merged first)